### PR TITLE
не перезаписывать pfs.specs если он уже существует

### DIFF
--- a/project-files/usr/bin/pfs
+++ b/project-files/usr/bin/pfs
@@ -94,7 +94,7 @@ pack_name="$(basename "${1%.$EXT}")"
 [ "$3" ] && pack_name="$3"
 #[ "$(pwd)" != "/" ] && find "${source_dir}${PFSDIR}/mount/" -mindepth 1 -maxdepth 1  -exec rm -rf "{}" \; 2>/dev/null
 mkdir -p "${dest_dir}${PFSDIR}/mount/${pack_name}" &&
-echo 'name="'$pack_name'"' > "${dest_dir}${PFSDIR}/mount/${pack_name}/pfs.specs" &&
+[ -f "${dest_dir}${PFSDIR}/mount/${pack_name}/pfs.specs" ] || echo 'name="'$pack_name'"' > "${dest_dir}${PFSDIR}/mount/${pack_name}/pfs.specs" &&
 find "${source_dir}" ! -type d        | sed "s:$source_dir::" |egrep -v '^/.wh..wh.|^'$PFSDIR'' > "${dest_dir}${PFSDIR}/mount/${pack_name}/pfs.files" &&
 find "${source_dir}"   -type d -empty | sed "s:$source_dir::" |egrep -v '^/.wh..wh.|^'$PFSDIR'' > "${dest_dir}${PFSDIR}/mount/${pack_name}/pfs.dirs.empty" #&&
 #[ -s "${dest_dir}${PFSDIR}/mount/${pack_name}/pfs.dirs.empty" ] || rm "${dest_dir}${PFSDIR}/mount/${pack_name}/pfs.dirs.empty"


### PR DESCRIPTION
в pfs.specs может находится описание, оно должно сохранятся. Если файла нет, то создается как обычно.